### PR TITLE
fix: change local path branch warning to info level

### DIFF
--- a/src/diracxdocs/plugin.py
+++ b/src/diracxdocs/plugin.py
@@ -68,7 +68,7 @@ class RepoItem(Config):  # type: ignore
             raise PluginError("repo does not define a url or a path")
 
         if Path(self.url).is_dir() and self.branch:
-            log.warning(f"{self.url} is a path, ignoring branch option {self.branch}")
+            log.info(f"{self.url} is a path, ignoring branch option {self.branch}")
 
 
 class DiracXDocsConfig(Config):  # type: ignore


### PR DESCRIPTION
## Summary
- Changes log level from warning to info when local paths are used with branch options
- Local paths with branch options are valid for development workflows
- Reduces noise in logs by not treating this as a problematic condition

🤖 Generated with [Claude Code](https://claude.ai/code)